### PR TITLE
style: apply google-java-format to all Java files

### DIFF
--- a/src/main/java/br/com/nicomaia/server/Main.java
+++ b/src/main/java/br/com/nicomaia/server/Main.java
@@ -4,9 +4,9 @@ import br.com.nicomaia.server.config.ServerConfig;
 import br.com.nicomaia.server.connection.ConnectionHandler;
 
 public class Main {
-    public static void main(String[] args) {
-        UpdateChecker.checkAsync();
-        var config = ServerConfig.fromArgs(args);
-        new ConnectionHandler(config).start();
-    }
+  public static void main(String[] args) {
+    UpdateChecker.checkAsync();
+    var config = ServerConfig.fromArgs(args);
+    new ConnectionHandler(config).start();
+  }
 }

--- a/src/main/java/br/com/nicomaia/server/UpdateChecker.java
+++ b/src/main/java/br/com/nicomaia/server/UpdateChecker.java
@@ -8,103 +8,116 @@ import java.time.Duration;
 
 public class UpdateChecker {
 
-    private static final String CURRENT_VERSION = loadVersion();
-    private static final String GITHUB_REPO = "josenicomaia/socks-server";
-    private static final String RELEASES_URL = "https://api.github.com/repos/" + GITHUB_REPO + "/releases/latest";
+  private static final String CURRENT_VERSION = loadVersion();
+  private static final String GITHUB_REPO = "josenicomaia/socks-server";
+  private static final String RELEASES_URL =
+      "https://api.github.com/repos/" + GITHUB_REPO + "/releases/latest";
 
-    private static String loadVersion() {
-        try (var stream = UpdateChecker.class.getClassLoader().getResourceAsStream("version.properties")) {
-            if (stream == null) return "0.0.0";
-            var props = new java.util.Properties();
-            props.load(stream);
-            String version = props.getProperty("version", "0.0.0");
-            // Strip -SNAPSHOT suffix for comparison
-            return version.replace("-SNAPSHOT", "");
-        } catch (Exception e) {
-            return "0.0.0";
-        }
+  private static String loadVersion() {
+    try (var stream =
+        UpdateChecker.class.getClassLoader().getResourceAsStream("version.properties")) {
+      if (stream == null) return "0.0.0";
+      var props = new java.util.Properties();
+      props.load(stream);
+      String version = props.getProperty("version", "0.0.0");
+      // Strip -SNAPSHOT suffix for comparison
+      return version.replace("-SNAPSHOT", "");
+    } catch (Exception e) {
+      return "0.0.0";
     }
+  }
 
-    public static void checkAsync() {
-        Thread.ofVirtual().name("update-checker").start(() -> {
-            try {
+  public static void checkAsync() {
+    Thread.ofVirtual()
+        .name("update-checker")
+        .start(
+            () -> {
+              try {
                 String latestVersion = fetchLatestVersion();
                 if (latestVersion != null && isNewer(latestVersion, CURRENT_VERSION)) {
-                    System.out.println();
-                    System.out.println("╔════════════════════════════════════════════════════════════╗");
-                    System.out.println("║  A new version of socks-server is available: " + padRight(latestVersion, 13) + "║");
-                    System.out.println("║  You are running version: " + padRight(CURRENT_VERSION, 33) + "║");
-                    System.out.println("║                                                            ║");
-                    System.out.println("║  https://github.com/" + padRight(GITHUB_REPO + "/releases", 39) + "║");
-                    System.out.println("╚════════════════════════════════════════════════════════════╝");
-                    System.out.println();
+                  System.out.println();
+                  System.out.println(
+                      "╔════════════════════════════════════════════════════════════╗");
+                  System.out.println(
+                      "║  A new version of socks-server is available: "
+                          + padRight(latestVersion, 13)
+                          + "║");
+                  System.out.println(
+                      "║  You are running version: " + padRight(CURRENT_VERSION, 33) + "║");
+                  System.out.println(
+                      "║                                                            ║");
+                  System.out.println(
+                      "║  https://github.com/" + padRight(GITHUB_REPO + "/releases", 39) + "║");
+                  System.out.println(
+                      "╚════════════════════════════════════════════════════════════╝");
+                  System.out.println();
                 }
-            } catch (Exception ignored) {
+              } catch (Exception ignored) {
                 // Silently fail — update check should never block or crash the app
-            }
-        });
+              }
+            });
+  }
+
+  private static String fetchLatestVersion() throws Exception {
+    try (HttpClient client =
+        HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(3)).build()) {
+
+      HttpRequest request =
+          HttpRequest.newBuilder()
+              .uri(URI.create(RELEASES_URL))
+              .header("Accept", "application/vnd.github.v3+json")
+              .timeout(Duration.ofSeconds(5))
+              .GET()
+              .build();
+
+      HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+      if (response.statusCode() != 200) {
+        return null;
+      }
+
+      // Lightweight JSON parsing — extract "tag_name" without a JSON library
+      String body = response.body();
+      int tagIndex = body.indexOf("\"tag_name\"");
+      if (tagIndex == -1) return null;
+
+      int valueStart = body.indexOf('"', tagIndex + 10) + 1;
+      int valueEnd = body.indexOf('"', valueStart);
+      String tagName = body.substring(valueStart, valueEnd);
+
+      // Strip leading 'v' if present (e.g., "v1.2.0" → "1.2.0")
+      return tagName.startsWith("v") ? tagName.substring(1) : tagName;
     }
+  }
 
-    private static String fetchLatestVersion() throws Exception {
-        try (HttpClient client = HttpClient.newBuilder()
-                .connectTimeout(Duration.ofSeconds(3))
-                .build()) {
+  static boolean isNewer(String remote, String local) {
+    int[] remoteParts = parseVersion(remote);
+    int[] localParts = parseVersion(local);
 
-            HttpRequest request = HttpRequest.newBuilder()
-                    .uri(URI.create(RELEASES_URL))
-                    .header("Accept", "application/vnd.github.v3+json")
-                    .timeout(Duration.ofSeconds(5))
-                    .GET()
-                    .build();
-
-            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
-
-            if (response.statusCode() != 200) {
-                return null;
-            }
-
-            // Lightweight JSON parsing — extract "tag_name" without a JSON library
-            String body = response.body();
-            int tagIndex = body.indexOf("\"tag_name\"");
-            if (tagIndex == -1) return null;
-
-            int valueStart = body.indexOf('"', tagIndex + 10) + 1;
-            int valueEnd = body.indexOf('"', valueStart);
-            String tagName = body.substring(valueStart, valueEnd);
-
-            // Strip leading 'v' if present (e.g., "v1.2.0" → "1.2.0")
-            return tagName.startsWith("v") ? tagName.substring(1) : tagName;
-        }
+    for (int i = 0; i < Math.max(remoteParts.length, localParts.length); i++) {
+      int r = i < remoteParts.length ? remoteParts[i] : 0;
+      int l = i < localParts.length ? localParts[i] : 0;
+      if (r > l) return true;
+      if (r < l) return false;
     }
+    return false;
+  }
 
-    static boolean isNewer(String remote, String local) {
-        int[] remoteParts = parseVersion(remote);
-        int[] localParts = parseVersion(local);
-
-        for (int i = 0; i < Math.max(remoteParts.length, localParts.length); i++) {
-            int r = i < remoteParts.length ? remoteParts[i] : 0;
-            int l = i < localParts.length ? localParts[i] : 0;
-            if (r > l) return true;
-            if (r < l) return false;
-        }
-        return false;
+  private static int[] parseVersion(String version) {
+    String[] parts = version.split("\\.");
+    int[] result = new int[parts.length];
+    for (int i = 0; i < parts.length; i++) {
+      try {
+        result[i] = Integer.parseInt(parts[i]);
+      } catch (NumberFormatException e) {
+        result[i] = 0;
+      }
     }
+    return result;
+  }
 
-    private static int[] parseVersion(String version) {
-        String[] parts = version.split("\\.");
-        int[] result = new int[parts.length];
-        for (int i = 0; i < parts.length; i++) {
-            try {
-                result[i] = Integer.parseInt(parts[i]);
-            } catch (NumberFormatException e) {
-                result[i] = 0;
-            }
-        }
-        return result;
-    }
-
-    private static String padRight(String text, int length) {
-        if (text.length() >= length) return text;
-        return text + " ".repeat(length - text.length());
-    }
+  private static String padRight(String text, int length) {
+    if (text.length() >= length) return text;
+    return text + " ".repeat(length - text.length());
+  }
 }

--- a/src/main/java/br/com/nicomaia/server/commands/Command.java
+++ b/src/main/java/br/com/nicomaia/server/commands/Command.java
@@ -1,8 +1,11 @@
 package br.com.nicomaia.server.commands;
 
 import br.com.nicomaia.server.net.AddressType;
-
 import java.net.InetAddress;
 
-public record Command(byte socksVersion, CommandType commandType, AddressType addressType, InetAddress address, int port) {
-}
+public record Command(
+    byte socksVersion,
+    CommandType commandType,
+    AddressType addressType,
+    InetAddress address,
+    int port) {}

--- a/src/main/java/br/com/nicomaia/server/commands/CommandResponse.java
+++ b/src/main/java/br/com/nicomaia/server/commands/CommandResponse.java
@@ -1,36 +1,35 @@
 package br.com.nicomaia.server.commands;
 
 import br.com.nicomaia.server.net.AddressType;
-
 import java.io.ByteArrayOutputStream;
 import java.net.Socket;
 
 public abstract class CommandResponse {
-    private final Command command;
-    private final ResponseType responseType;
+  private final Command command;
+  private final ResponseType responseType;
 
-    public CommandResponse(Command command, ResponseType responseType) {
-        this.command = command;
-        this.responseType = responseType;
+  public CommandResponse(Command command, ResponseType responseType) {
+    this.command = command;
+    this.responseType = responseType;
+  }
+
+  public byte[] getBytes(Socket client) {
+    // https://datatracker.ietf.org/doc/html/rfc1928#section-6
+    ByteArrayOutputStream stream = new ByteArrayOutputStream();
+    stream.write(command.socksVersion());
+    stream.write(responseType.getNumber());
+    stream.write(0x00);
+    stream.write(command.addressType().getTypeCode());
+
+    if (command.addressType() == AddressType.DOMAIN_NAME) {
+      stream.write(4);
     }
 
-    public byte[] getBytes(Socket client) {
-        // https://datatracker.ietf.org/doc/html/rfc1928#section-6
-        ByteArrayOutputStream stream = new ByteArrayOutputStream();
-        stream.write(command.socksVersion());
-        stream.write(responseType.getNumber());
-        stream.write(0x00);
-        stream.write(command.addressType().getTypeCode());
+    stream.writeBytes(client.getInetAddress().getAddress());
 
-        if (command.addressType() == AddressType.DOMAIN_NAME) {
-            stream.write(4);
-        }
+    stream.write((client.getPort() >>> 8) & 0xFF);
+    stream.write(client.getPort() & 0xFF);
 
-        stream.writeBytes(client.getInetAddress().getAddress());
-
-        stream.write((client.getPort() >>> 8) & 0xFF);
-        stream.write(client.getPort() & 0xFF);
-
-        return stream.toByteArray();
-    }
+    return stream.toByteArray();
+  }
 }

--- a/src/main/java/br/com/nicomaia/server/commands/CommandType.java
+++ b/src/main/java/br/com/nicomaia/server/commands/CommandType.java
@@ -3,26 +3,26 @@ package br.com.nicomaia.server.commands;
 import java.util.Arrays;
 
 public enum CommandType {
-    BIND((byte) 0x02),
-    BIND_REPLY((byte) 0x00),
-    CONNECT((byte) 0x01),
-    UDP_ASSOCIATE((byte) 0x03),
-    UDP_REPLY((byte) 0x00);
+  BIND((byte) 0x02),
+  BIND_REPLY((byte) 0x00),
+  CONNECT((byte) 0x01),
+  UDP_ASSOCIATE((byte) 0x03),
+  UDP_REPLY((byte) 0x00);
 
-    private final byte number;
+  private final byte number;
 
-    CommandType(byte number) {
-        this.number = number;
-    }
+  CommandType(byte number) {
+    this.number = number;
+  }
 
-    public byte getNumber() {
-        return number;
-    }
+  public byte getNumber() {
+    return number;
+  }
 
-    public static CommandType valueOf(byte number) {
-        return Arrays.stream(values())
-                .filter(commandType -> commandType.number == number)
-                .findFirst()
-                .get();
-    }
+  public static CommandType valueOf(byte number) {
+    return Arrays.stream(values())
+        .filter(commandType -> commandType.number == number)
+        .findFirst()
+        .get();
+  }
 }

--- a/src/main/java/br/com/nicomaia/server/commands/FailureCommandResponse.java
+++ b/src/main/java/br/com/nicomaia/server/commands/FailureCommandResponse.java
@@ -1,7 +1,7 @@
 package br.com.nicomaia.server.commands;
 
 public class FailureCommandResponse extends CommandResponse {
-    public FailureCommandResponse(Command command) {
-        super(command, ResponseType.SOCKS_SERVER_FAILURE);
-    }
+  public FailureCommandResponse(Command command) {
+    super(command, ResponseType.SOCKS_SERVER_FAILURE);
+  }
 }

--- a/src/main/java/br/com/nicomaia/server/commands/ResponseType.java
+++ b/src/main/java/br/com/nicomaia/server/commands/ResponseType.java
@@ -3,31 +3,31 @@ package br.com.nicomaia.server.commands;
 import java.util.Arrays;
 
 public enum ResponseType {
-    SUCCEEDED((byte) 0x00),
-    SOCKS_SERVER_FAILURE((byte) 0x01),
-    CONNECTION_NOT_ALLOWED((byte) 0x02),
-    NETWORK_UNREACHABLE((byte) 0x03),
-    HOST_UNREACHABLE((byte) 0x04),
-    CONNECTION_REFUSED((byte) 0x05),
-    TTL_EXPIRED((byte) 0x06),
-    COMMAND_NOT_SUPPORTED((byte) 0x07),
-    ADDRESS_TYPE_NOT_SUPPORTED((byte) 0x08),
-    UNASSIGNED((byte) 0x09);
+  SUCCEEDED((byte) 0x00),
+  SOCKS_SERVER_FAILURE((byte) 0x01),
+  CONNECTION_NOT_ALLOWED((byte) 0x02),
+  NETWORK_UNREACHABLE((byte) 0x03),
+  HOST_UNREACHABLE((byte) 0x04),
+  CONNECTION_REFUSED((byte) 0x05),
+  TTL_EXPIRED((byte) 0x06),
+  COMMAND_NOT_SUPPORTED((byte) 0x07),
+  ADDRESS_TYPE_NOT_SUPPORTED((byte) 0x08),
+  UNASSIGNED((byte) 0x09);
 
-    private final byte number;
+  private final byte number;
 
-    ResponseType(byte number) {
-        this.number = number;
-    }
+  ResponseType(byte number) {
+    this.number = number;
+  }
 
-    public byte getNumber() {
-        return number;
-    }
+  public byte getNumber() {
+    return number;
+  }
 
-    public static ResponseType valueOf(byte number) {
-        return Arrays.stream(values())
-                .filter(commandType -> commandType.number == number)
-                .findFirst()
-                .get();
-    }
+  public static ResponseType valueOf(byte number) {
+    return Arrays.stream(values())
+        .filter(commandType -> commandType.number == number)
+        .findFirst()
+        .get();
+  }
 }

--- a/src/main/java/br/com/nicomaia/server/commands/SuccessCommandResponse.java
+++ b/src/main/java/br/com/nicomaia/server/commands/SuccessCommandResponse.java
@@ -3,10 +3,10 @@ package br.com.nicomaia.server.commands;
 import java.net.Socket;
 
 public class SuccessCommandResponse extends CommandResponse {
-    private final Socket socket;
+  private final Socket socket;
 
-    public SuccessCommandResponse(Command command, Socket socket) {
-        super(command, ResponseType.SUCCEEDED);
-        this.socket = socket;
-    }
+  public SuccessCommandResponse(Command command, Socket socket) {
+    super(command, ResponseType.SUCCEEDED);
+    this.socket = socket;
+  }
 }

--- a/src/main/java/br/com/nicomaia/server/commands/handlers/CommandHandler.java
+++ b/src/main/java/br/com/nicomaia/server/commands/handlers/CommandHandler.java
@@ -1,9 +1,8 @@
 package br.com.nicomaia.server.commands.handlers;
 
 import br.com.nicomaia.server.commands.Command;
-
 import java.net.Socket;
 
 public interface CommandHandler {
-    void handle(Socket clientSocket, Command command);
+  void handle(Socket clientSocket, Command command);
 }

--- a/src/main/java/br/com/nicomaia/server/commands/handlers/ConnectHandler.java
+++ b/src/main/java/br/com/nicomaia/server/commands/handlers/ConnectHandler.java
@@ -1,11 +1,10 @@
 package br.com.nicomaia.server.commands.handlers;
 
-import br.com.nicomaia.server.transfer.ClientServerTransfer;
 import br.com.nicomaia.server.commands.Command;
 import br.com.nicomaia.server.commands.CommandResponse;
 import br.com.nicomaia.server.commands.FailureCommandResponse;
 import br.com.nicomaia.server.commands.SuccessCommandResponse;
-
+import br.com.nicomaia.server.transfer.ClientServerTransfer;
 import java.io.IOException;
 import java.net.Socket;
 import java.util.logging.Level;
@@ -13,32 +12,32 @@ import java.util.logging.Logger;
 
 public class ConnectHandler implements CommandHandler {
 
-    private static final Logger logger = Logger.getLogger(ConnectHandler.class.getName());
+  private static final Logger logger = Logger.getLogger(ConnectHandler.class.getName());
 
-    public void handle(Socket client, Command command) {
-        try {
-            Socket proxiedConnection = new Socket(command.address(), command.port());
-            var response = new SuccessCommandResponse(command, proxiedConnection);
+  public void handle(Socket client, Command command) {
+    try {
+      Socket proxiedConnection = new Socket(command.address(), command.port());
+      var response = new SuccessCommandResponse(command, proxiedConnection);
 
-            ClientServerTransfer transfer = new ClientServerTransfer(client, proxiedConnection);
-            transfer.start();
+      ClientServerTransfer transfer = new ClientServerTransfer(client, proxiedConnection);
+      transfer.start();
 
-            sendResponse(client, response);
-        } catch (IOException e) {
-            logger.log(Level.WARNING, "Connect failed to " + command.address() + ":" + command.port(), e);
+      sendResponse(client, response);
+    } catch (IOException e) {
+      logger.log(Level.WARNING, "Connect failed to " + command.address() + ":" + command.port(), e);
 
-            try {
-                sendResponse(client, new FailureCommandResponse(command));
-            } catch (IOException ex) {
-                throw new RuntimeException(ex);
-            }
-        }
+      try {
+        sendResponse(client, new FailureCommandResponse(command));
+      } catch (IOException ex) {
+        throw new RuntimeException(ex);
+      }
     }
+  }
 
-    private void sendResponse(Socket client, CommandResponse response) throws IOException {
-        logger.info(response.toString());
+  private void sendResponse(Socket client, CommandResponse response) throws IOException {
+    logger.info(response.toString());
 
-        client.getOutputStream().write(response.getBytes(client));
-        client.getOutputStream().flush();
-    }
+    client.getOutputStream().write(response.getBytes(client));
+    client.getOutputStream().flush();
+  }
 }

--- a/src/main/java/br/com/nicomaia/server/commands/handlers/HandlersHolder.java
+++ b/src/main/java/br/com/nicomaia/server/commands/handlers/HandlersHolder.java
@@ -1,22 +1,21 @@
 package br.com.nicomaia.server.commands.handlers;
 
 import br.com.nicomaia.server.commands.CommandType;
-
 import java.util.HashMap;
 import java.util.Map;
 
 public class HandlersHolder {
-    private final Map<CommandType, CommandHandler> handlers;
+  private final Map<CommandType, CommandHandler> handlers;
 
-    public HandlersHolder() {
-        handlers = new HashMap<>();
-    }
+  public HandlersHolder() {
+    handlers = new HashMap<>();
+  }
 
-    public void register(CommandType commandType, CommandHandler handler) {
-        handlers.put(commandType, handler);
-    }
+  public void register(CommandType commandType, CommandHandler handler) {
+    handlers.put(commandType, handler);
+  }
 
-    public CommandHandler get(CommandType commandType) {
-        return handlers.get(commandType);
-    }
+  public CommandHandler get(CommandType commandType) {
+    return handlers.get(commandType);
+  }
 }

--- a/src/main/java/br/com/nicomaia/server/config/ServerConfig.java
+++ b/src/main/java/br/com/nicomaia/server/config/ServerConfig.java
@@ -8,27 +8,26 @@ import br.com.nicomaia.server.net.AddressType;
 import br.com.nicomaia.server.net.resolvers.DomainInetResolver;
 import br.com.nicomaia.server.net.resolvers.InetResolver;
 import br.com.nicomaia.server.net.resolvers.IpInetResolver;
-
 import java.util.Map;
 
 public record ServerConfig(int port, AddressResolver addressResolver, HandlersHolder handlers) {
 
-    private static final int DEFAULT_PORT = 5353;
+  private static final int DEFAULT_PORT = 5353;
 
-    public static ServerConfig fromArgs(String[] args) {
-        int port = (args.length > 0) ? Integer.parseInt(args[0]) : DEFAULT_PORT;
+  public static ServerConfig fromArgs(String[] args) {
+    int port = (args.length > 0) ? Integer.parseInt(args[0]) : DEFAULT_PORT;
 
-        Map<AddressType, InetResolver> resolvers = Map.of(
-                AddressType.IPV4, new IpInetResolver(),
-                AddressType.IPV6, new IpInetResolver(),
-                AddressType.DOMAIN_NAME, new DomainInetResolver()
-        );
+    Map<AddressType, InetResolver> resolvers =
+        Map.of(
+            AddressType.IPV4, new IpInetResolver(),
+            AddressType.IPV6, new IpInetResolver(),
+            AddressType.DOMAIN_NAME, new DomainInetResolver());
 
-        AddressResolver addressResolver = new AddressResolver(resolvers);
+    AddressResolver addressResolver = new AddressResolver(resolvers);
 
-        HandlersHolder handlers = new HandlersHolder();
-        handlers.register(CommandType.CONNECT, new ConnectHandler());
+    HandlersHolder handlers = new HandlersHolder();
+    handlers.register(CommandType.CONNECT, new ConnectHandler());
 
-        return new ServerConfig(port, addressResolver, handlers);
-    }
+    return new ServerConfig(port, addressResolver, handlers);
+  }
 }

--- a/src/main/java/br/com/nicomaia/server/connection/ConnectionHandler.java
+++ b/src/main/java/br/com/nicomaia/server/connection/ConnectionHandler.java
@@ -2,7 +2,6 @@ package br.com.nicomaia.server.connection;
 
 import br.com.nicomaia.server.config.ServerConfig;
 import br.com.nicomaia.server.protocol.SocksProtocolHandler;
-
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.net.Socket;
@@ -11,40 +10,41 @@ import java.util.logging.Logger;
 
 public class ConnectionHandler {
 
-    private static final Logger logger = Logger.getLogger(ConnectionHandler.class.getName());
+  private static final Logger logger = Logger.getLogger(ConnectionHandler.class.getName());
 
-    private final ServerConfig config;
-    private final SocksProtocolHandler protocolHandler;
+  private final ServerConfig config;
+  private final SocksProtocolHandler protocolHandler;
 
-    public ConnectionHandler(ServerConfig config) {
-        this.config = config;
-        this.protocolHandler = new SocksProtocolHandler(config.addressResolver(), config.handlers());
-    }
+  public ConnectionHandler(ServerConfig config) {
+    this.config = config;
+    this.protocolHandler = new SocksProtocolHandler(config.addressResolver(), config.handlers());
+  }
 
-    public void start() {
-        try (var serverSocket = new ServerSocket(config.port())) {
-            logger.info("SOCKS server listening on port " + config.port());
+  public void start() {
+    try (var serverSocket = new ServerSocket(config.port())) {
+      logger.info("SOCKS server listening on port " + config.port());
 
-            while (true) {
-                try {
-                    Socket clientSocket = serverSocket.accept();
+      while (true) {
+        try {
+          Socket clientSocket = serverSocket.accept();
 
-                    Thread.ofVirtual()
-                            .name("client-handler-", clientSocket.hashCode())
-                            .start(() -> {
-                                logger.fine(() -> "Starting " + Thread.currentThread());
-                                logger.fine(() -> clientSocket.toString());
+          Thread.ofVirtual()
+              .name("client-handler-", clientSocket.hashCode())
+              .start(
+                  () -> {
+                    logger.fine(() -> "Starting " + Thread.currentThread());
+                    logger.fine(() -> clientSocket.toString());
 
-                                protocolHandler.handle(clientSocket);
+                    protocolHandler.handle(clientSocket);
 
-                                logger.fine(() -> "Terminating " + Thread.currentThread());
-                            });
-                } catch (IOException e) {
-                    logger.log(Level.WARNING, "Error accepting connection", e);
-                }
-            }
+                    logger.fine(() -> "Terminating " + Thread.currentThread());
+                  });
         } catch (IOException e) {
-            logger.log(Level.SEVERE, "Failed to start server", e);
+          logger.log(Level.WARNING, "Error accepting connection", e);
         }
+      }
+    } catch (IOException e) {
+      logger.log(Level.SEVERE, "Failed to start server", e);
     }
+  }
 }

--- a/src/main/java/br/com/nicomaia/server/net/Address.java
+++ b/src/main/java/br/com/nicomaia/server/net/Address.java
@@ -1,4 +1,3 @@
 package br.com.nicomaia.server.net;
 
-public record Address(byte[] content, AddressType addressType) {
-}
+public record Address(byte[] content, AddressType addressType) {}

--- a/src/main/java/br/com/nicomaia/server/net/AddressResolver.java
+++ b/src/main/java/br/com/nicomaia/server/net/AddressResolver.java
@@ -1,25 +1,25 @@
 package br.com.nicomaia.server.net;
 
 import br.com.nicomaia.server.net.resolvers.InetResolver;
-
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Map;
 
 public class AddressResolver {
-    private final Map<AddressType, InetResolver> resolvers;
+  private final Map<AddressType, InetResolver> resolvers;
 
-    public AddressResolver(Map<AddressType, InetResolver> resolvers) {
-        this.resolvers = resolvers;
+  public AddressResolver(Map<AddressType, InetResolver> resolvers) {
+    this.resolvers = resolvers;
+  }
+
+  public InetAddress resolve(Address address)
+      throws UnknownHostException, ResolverNotFoundException {
+    InetResolver resolver = resolvers.get(address.addressType());
+
+    if (resolver == null) {
+      throw new ResolverNotFoundException();
     }
 
-    public InetAddress resolve(Address address) throws UnknownHostException, ResolverNotFoundException {
-        InetResolver resolver = resolvers.get(address.addressType());
-
-        if (resolver == null) {
-            throw new ResolverNotFoundException();
-        }
-
-        return resolver.resolve(address);
-    }
+    return resolver.resolve(address);
+  }
 }

--- a/src/main/java/br/com/nicomaia/server/net/AddressType.java
+++ b/src/main/java/br/com/nicomaia/server/net/AddressType.java
@@ -3,24 +3,27 @@ package br.com.nicomaia.server.net;
 import java.util.Arrays;
 
 public enum AddressType {
-    IPV4((byte) 0x01),
-    IPV6((byte) 0x04),
-    DOMAIN_NAME((byte) 0x03);
+  IPV4((byte) 0x01),
+  IPV6((byte) 0x04),
+  DOMAIN_NAME((byte) 0x03);
 
-    private final byte typeCode;
+  private final byte typeCode;
 
-    AddressType(byte typeCode) {
-        this.typeCode = typeCode;
-    }
+  AddressType(byte typeCode) {
+    this.typeCode = typeCode;
+  }
 
-    public byte getTypeCode() {
-        return typeCode;
-    }
+  public byte getTypeCode() {
+    return typeCode;
+  }
 
-    public static AddressType valueOf(byte typeCode) {
-        return Arrays.stream(values())
-                .filter(commandType -> commandType.typeCode == typeCode)
-                .findFirst()
-                .orElseThrow(() -> new IllegalArgumentException("Unknown address type: 0x" + String.format("%02X", typeCode)));
-    }
+  public static AddressType valueOf(byte typeCode) {
+    return Arrays.stream(values())
+        .filter(commandType -> commandType.typeCode == typeCode)
+        .findFirst()
+        .orElseThrow(
+            () ->
+                new IllegalArgumentException(
+                    "Unknown address type: 0x" + String.format("%02X", typeCode)));
+  }
 }

--- a/src/main/java/br/com/nicomaia/server/net/ResolverNotFoundException.java
+++ b/src/main/java/br/com/nicomaia/server/net/ResolverNotFoundException.java
@@ -1,4 +1,3 @@
 package br.com.nicomaia.server.net;
 
-public class ResolverNotFoundException extends Exception {
-}
+public class ResolverNotFoundException extends Exception {}

--- a/src/main/java/br/com/nicomaia/server/net/resolvers/DomainInetResolver.java
+++ b/src/main/java/br/com/nicomaia/server/net/resolvers/DomainInetResolver.java
@@ -1,12 +1,11 @@
 package br.com.nicomaia.server.net.resolvers;
 
 import br.com.nicomaia.server.net.Address;
-
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 
 public class DomainInetResolver implements InetResolver {
-    public InetAddress resolve(Address address) throws UnknownHostException {
-        return InetAddress.getByName(new String(address.content()));
-    }
+  public InetAddress resolve(Address address) throws UnknownHostException {
+    return InetAddress.getByName(new String(address.content()));
+  }
 }

--- a/src/main/java/br/com/nicomaia/server/net/resolvers/InetResolver.java
+++ b/src/main/java/br/com/nicomaia/server/net/resolvers/InetResolver.java
@@ -1,10 +1,9 @@
 package br.com.nicomaia.server.net.resolvers;
 
 import br.com.nicomaia.server.net.Address;
-
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 
 public interface InetResolver {
-    InetAddress resolve(Address address) throws UnknownHostException;
+  InetAddress resolve(Address address) throws UnknownHostException;
 }

--- a/src/main/java/br/com/nicomaia/server/net/resolvers/IpInetResolver.java
+++ b/src/main/java/br/com/nicomaia/server/net/resolvers/IpInetResolver.java
@@ -1,12 +1,11 @@
 package br.com.nicomaia.server.net.resolvers;
 
 import br.com.nicomaia.server.net.Address;
-
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 
 public class IpInetResolver implements InetResolver {
-    public InetAddress resolve(Address address) throws UnknownHostException {
-        return InetAddress.getByAddress(address.content());
-    }
+  public InetAddress resolve(Address address) throws UnknownHostException {
+    return InetAddress.getByAddress(address.content());
+  }
 }

--- a/src/main/java/br/com/nicomaia/server/protocol/AuthRequest.java
+++ b/src/main/java/br/com/nicomaia/server/protocol/AuthRequest.java
@@ -2,5 +2,5 @@ package br.com.nicomaia.server.protocol;
 
 import java.util.Set;
 
-public record AuthRequest(byte socksVersion, byte availableClientAuthTypes, Set<SupportedAuthType> supportedAuthTypes) {
-}
+public record AuthRequest(
+    byte socksVersion, byte availableClientAuthTypes, Set<SupportedAuthType> supportedAuthTypes) {}

--- a/src/main/java/br/com/nicomaia/server/protocol/AuthResponse.java
+++ b/src/main/java/br/com/nicomaia/server/protocol/AuthResponse.java
@@ -2,7 +2,7 @@ package br.com.nicomaia.server.protocol;
 
 public record AuthResponse(byte socksVersion, SupportedAuthType chosenAuthMethod) {
 
-    public byte[] toBytes() {
-        return new byte[]{socksVersion, chosenAuthMethod.getNumber()};
-    }
+  public byte[] toBytes() {
+    return new byte[] {socksVersion, chosenAuthMethod.getNumber()};
+  }
 }

--- a/src/main/java/br/com/nicomaia/server/protocol/SocketReader.java
+++ b/src/main/java/br/com/nicomaia/server/protocol/SocketReader.java
@@ -2,38 +2,37 @@ package br.com.nicomaia.server.protocol;
 
 import br.com.nicomaia.server.net.Address;
 import br.com.nicomaia.server.net.AddressType;
-
 import java.io.IOException;
 import java.io.InputStream;
 
 public class SocketReader {
 
-    public static Address readAddress(AddressType addressType, InputStream in) throws IOException {
-        byte[] buffer;
+  public static Address readAddress(AddressType addressType, InputStream in) throws IOException {
+    byte[] buffer;
 
-        if (AddressType.IPV6 == addressType) {
-            buffer = new byte[16];
-        } else if (AddressType.IPV4 == addressType) {
-            buffer = new byte[4];
-        } else if (AddressType.DOMAIN_NAME == addressType) {
-            buffer = new byte[readDomainLength(in)];
-        } else {
-            throw new IOException("Unsupported address type: " + addressType);
-        }
-
-        in.read(buffer);
-        return new Address(buffer, addressType);
+    if (AddressType.IPV6 == addressType) {
+      buffer = new byte[16];
+    } else if (AddressType.IPV4 == addressType) {
+      buffer = new byte[4];
+    } else if (AddressType.DOMAIN_NAME == addressType) {
+      buffer = new byte[readDomainLength(in)];
+    } else {
+      throw new IOException("Unsupported address type: " + addressType);
     }
 
-    public static int readPort(InputStream in) throws IOException {
-        byte[] buffer = new byte[2];
-        in.read(buffer);
-        return ((buffer[0] & 0xFF) << 8) | (buffer[1] & 0xFF);
-    }
+    in.read(buffer);
+    return new Address(buffer, addressType);
+  }
 
-    private static byte readDomainLength(InputStream in) throws IOException {
-        byte[] buffer = new byte[1];
-        in.read(buffer);
-        return buffer[0];
-    }
+  public static int readPort(InputStream in) throws IOException {
+    byte[] buffer = new byte[2];
+    in.read(buffer);
+    return ((buffer[0] & 0xFF) << 8) | (buffer[1] & 0xFF);
+  }
+
+  private static byte readDomainLength(InputStream in) throws IOException {
+    byte[] buffer = new byte[1];
+    in.read(buffer);
+    return buffer[0];
+  }
 }

--- a/src/main/java/br/com/nicomaia/server/protocol/SocksProtocolHandler.java
+++ b/src/main/java/br/com/nicomaia/server/protocol/SocksProtocolHandler.java
@@ -6,9 +6,6 @@ import br.com.nicomaia.server.commands.handlers.HandlersHolder;
 import br.com.nicomaia.server.net.Address;
 import br.com.nicomaia.server.net.AddressResolver;
 import br.com.nicomaia.server.net.AddressType;
-import br.com.nicomaia.server.net.ResolverNotFoundException;
-
-import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetAddress;
 import java.net.Socket;
@@ -17,56 +14,58 @@ import java.util.logging.Logger;
 
 public class SocksProtocolHandler {
 
-    private static final Logger logger = Logger.getLogger(SocksProtocolHandler.class.getName());
+  private static final Logger logger = Logger.getLogger(SocksProtocolHandler.class.getName());
 
-    private final AddressResolver addressResolver;
-    private final HandlersHolder handlers;
+  private final AddressResolver addressResolver;
+  private final HandlersHolder handlers;
 
-    public SocksProtocolHandler(AddressResolver addressResolver, HandlersHolder handlers) {
-        this.addressResolver = addressResolver;
-        this.handlers = handlers;
+  public SocksProtocolHandler(AddressResolver addressResolver, HandlersHolder handlers) {
+    this.addressResolver = addressResolver;
+    this.handlers = handlers;
+  }
+
+  public void handle(Socket clientSocket) {
+    try {
+      InputStream in = clientSocket.getInputStream();
+
+      // --- Auth Negotiation ---
+      byte[] buffer = new byte[2];
+      in.read(buffer);
+
+      byte socksVersion = buffer[0];
+      byte availableClientAuthTypes = buffer[1];
+
+      buffer = new byte[availableClientAuthTypes];
+      in.read(buffer);
+
+      var authRequest =
+          new AuthRequest(
+              socksVersion, availableClientAuthTypes, SupportedAuthType.valueOf(buffer));
+      var authResponse = new AuthResponse(socksVersion, SupportedAuthType.NO_AUTH);
+
+      logger.info(authRequest.toString());
+      logger.info(authResponse.toString());
+
+      clientSocket.getOutputStream().write(authResponse.toBytes());
+
+      // --- Command ---
+      buffer = new byte[4];
+      in.read(buffer);
+
+      socksVersion = buffer[0];
+      CommandType commandType = CommandType.valueOf(buffer[1]);
+      AddressType addressType = AddressType.valueOf(buffer[3]);
+
+      Address address = SocketReader.readAddress(addressType, in);
+      InetAddress inetAddress = addressResolver.resolve(address);
+      int port = SocketReader.readPort(in);
+
+      var command = new Command(socksVersion, commandType, addressType, inetAddress, port);
+      logger.info(command.toString());
+
+      handlers.get(commandType).handle(clientSocket, command);
+    } catch (Exception e) {
+      logger.log(Level.WARNING, "Error handling SOCKS connection", e);
     }
-
-    public void handle(Socket clientSocket) {
-        try {
-            InputStream in = clientSocket.getInputStream();
-
-            // --- Auth Negotiation ---
-            byte[] buffer = new byte[2];
-            in.read(buffer);
-
-            byte socksVersion = buffer[0];
-            byte availableClientAuthTypes = buffer[1];
-
-            buffer = new byte[availableClientAuthTypes];
-            in.read(buffer);
-
-            var authRequest = new AuthRequest(socksVersion, availableClientAuthTypes, SupportedAuthType.valueOf(buffer));
-            var authResponse = new AuthResponse(socksVersion, SupportedAuthType.NO_AUTH);
-
-            logger.info(authRequest.toString());
-            logger.info(authResponse.toString());
-
-            clientSocket.getOutputStream().write(authResponse.toBytes());
-
-            // --- Command ---
-            buffer = new byte[4];
-            in.read(buffer);
-
-            socksVersion = buffer[0];
-            CommandType commandType = CommandType.valueOf(buffer[1]);
-            AddressType addressType = AddressType.valueOf(buffer[3]);
-
-            Address address = SocketReader.readAddress(addressType, in);
-            InetAddress inetAddress = addressResolver.resolve(address);
-            int port = SocketReader.readPort(in);
-
-            var command = new Command(socksVersion, commandType, addressType, inetAddress, port);
-            logger.info(command.toString());
-
-            handlers.get(commandType).handle(clientSocket, command);
-        } catch (Exception e) {
-            logger.log(Level.WARNING, "Error handling SOCKS connection", e);
-        }
-    }
+  }
 }

--- a/src/main/java/br/com/nicomaia/server/protocol/SupportedAuthType.java
+++ b/src/main/java/br/com/nicomaia/server/protocol/SupportedAuthType.java
@@ -7,33 +7,36 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 public enum SupportedAuthType {
-    NO_AUTH((byte) 0x00),
-    USERNAME((byte) 0x02);
+  NO_AUTH((byte) 0x00),
+  USERNAME((byte) 0x02);
 
-    private final byte number;
+  private final byte number;
 
-    SupportedAuthType(byte number) {
-        this.number = number;
+  SupportedAuthType(byte number) {
+    this.number = number;
+  }
+
+  public byte getNumber() {
+    return number;
+  }
+
+  public static Set<SupportedAuthType> valueOf(byte[] buffer) {
+    Set<SupportedAuthType> parsedTypes = new HashSet<>();
+
+    Map<Byte, SupportedAuthType> numberIndex =
+        Arrays.stream(values())
+            .collect(
+                Collectors.toMap(
+                    SupportedAuthType::getNumber, supportedAuthType -> supportedAuthType));
+
+    for (byte number : buffer) {
+      SupportedAuthType supportedAuthType = numberIndex.get(number);
+
+      if (supportedAuthType != null) {
+        parsedTypes.add(supportedAuthType);
+      }
     }
 
-    public byte getNumber() {
-        return number;
-    }
-
-    public static Set<SupportedAuthType> valueOf(byte[] buffer) {
-        Set<SupportedAuthType> parsedTypes = new HashSet<>();
-
-        Map<Byte, SupportedAuthType> numberIndex = Arrays.stream(values())
-                .collect(Collectors.toMap(SupportedAuthType::getNumber, supportedAuthType -> supportedAuthType));
-
-        for (byte number : buffer) {
-            SupportedAuthType supportedAuthType = numberIndex.get(number);
-
-            if (supportedAuthType != null) {
-                parsedTypes.add(supportedAuthType);
-            }
-        }
-
-        return parsedTypes;
-    }
+    return parsedTypes;
+  }
 }

--- a/src/main/java/br/com/nicomaia/server/transfer/ClientServerTransfer.java
+++ b/src/main/java/br/com/nicomaia/server/transfer/ClientServerTransfer.java
@@ -6,67 +6,71 @@ import java.io.OutputStream;
 import java.net.Socket;
 
 public class ClientServerTransfer {
-    private static final int DEFAULT_BUFFER_SIZE = 8192;
-    private Thread clientToServerThread;
-    private Thread serverToClientThread;
+  private static final int DEFAULT_BUFFER_SIZE = 8192;
+  private Thread clientToServerThread;
+  private Thread serverToClientThread;
 
-    public ClientServerTransfer(Socket client, Socket server) {
-        prepareTransfers(client, server);
+  public ClientServerTransfer(Socket client, Socket server) {
+    prepareTransfers(client, server);
+  }
+
+  private void prepareTransfers(Socket client, Socket server) {
+    clientToServerThread =
+        Thread.ofVirtual()
+            .name(client + " => " + server)
+            .unstarted(
+                () -> {
+                  try {
+                    while (client.isConnected()) {
+                      transferTo(client.getInputStream(), server.getOutputStream());
+                      Thread.sleep(500);
+                    }
+                  } catch (IOException | InterruptedException e) {
+                    e.printStackTrace();
+
+                    try {
+                      client.close();
+                      server.close();
+                    } catch (IOException ex) {
+                      throw new RuntimeException(ex);
+                    }
+                  }
+                });
+
+    serverToClientThread =
+        Thread.ofVirtual()
+            .name(client + " <= " + server)
+            .unstarted(
+                () -> {
+                  try {
+                    while (server.isConnected()) {
+                      transferTo(server.getInputStream(), client.getOutputStream());
+                      Thread.sleep(500);
+                    }
+                  } catch (IOException | InterruptedException e) {
+                    e.printStackTrace();
+
+                    try {
+                      client.close();
+                      server.close();
+                    } catch (IOException ex) {
+                      throw new RuntimeException(ex);
+                    }
+                  }
+                });
+  }
+
+  private void transferTo(InputStream in, OutputStream out) throws IOException {
+    byte[] buffer = new byte[DEFAULT_BUFFER_SIZE];
+    int read;
+
+    while ((read = in.read(buffer, 0, DEFAULT_BUFFER_SIZE)) >= 0) {
+      out.write(buffer, 0, read);
     }
+  }
 
-    private void prepareTransfers(Socket client, Socket server) {
-        clientToServerThread = Thread.ofVirtual()
-                .name(client + " => " + server)
-                .unstarted(() -> {
-            try {
-                while (client.isConnected()) {
-                    transferTo(client.getInputStream(), server.getOutputStream());
-                    Thread.sleep(500);
-                }
-            } catch (IOException | InterruptedException e) {
-                e.printStackTrace();
-
-                try {
-                    client.close();
-                    server.close();
-                } catch (IOException ex) {
-                    throw new RuntimeException(ex);
-                }
-            }
-        });
-
-        serverToClientThread = Thread.ofVirtual()
-                .name(client + " <= " + server)
-                .unstarted(() -> {
-            try {
-                while (server.isConnected()) {
-                    transferTo(server.getInputStream(), client.getOutputStream());
-                    Thread.sleep(500);
-                }
-            } catch (IOException | InterruptedException e) {
-                e.printStackTrace();
-
-                try {
-                    client.close();
-                    server.close();
-                } catch (IOException ex) {
-                    throw new RuntimeException(ex);
-                }
-            }
-        });
-    }
-
-    private void transferTo(InputStream in, OutputStream out) throws IOException {
-        byte[] buffer = new byte[DEFAULT_BUFFER_SIZE];
-        int read;
-
-        while ((read = in.read(buffer, 0, DEFAULT_BUFFER_SIZE)) >= 0) {
-            out.write(buffer, 0, read);
-        }
-    }
-
-    public void start() {
-        serverToClientThread.start();
-        clientToServerThread.start();
-    }
+  public void start() {
+    serverToClientThread.start();
+    clientToServerThread.start();
+  }
 }

--- a/src/test/java/br/com/nicomaia/server/UpdateCheckerTest.java
+++ b/src/test/java/br/com/nicomaia/server/UpdateCheckerTest.java
@@ -1,45 +1,45 @@
 package br.com.nicomaia.server;
 
-import org.junit.jupiter.api.Test;
-
 import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
 
 class UpdateCheckerTest {
 
-    @Test
-    void shouldDetectNewerMajorVersion() {
-        assertTrue(UpdateChecker.isNewer("2.0.0", "1.0.0"));
-    }
+  @Test
+  void shouldDetectNewerMajorVersion() {
+    assertTrue(UpdateChecker.isNewer("2.0.0", "1.0.0"));
+  }
 
-    @Test
-    void shouldDetectNewerMinorVersion() {
-        assertTrue(UpdateChecker.isNewer("1.1.0", "1.0.0"));
-    }
+  @Test
+  void shouldDetectNewerMinorVersion() {
+    assertTrue(UpdateChecker.isNewer("1.1.0", "1.0.0"));
+  }
 
-    @Test
-    void shouldDetectNewerPatchVersion() {
-        assertTrue(UpdateChecker.isNewer("1.0.1", "1.0.0"));
-    }
+  @Test
+  void shouldDetectNewerPatchVersion() {
+    assertTrue(UpdateChecker.isNewer("1.0.1", "1.0.0"));
+  }
 
-    @Test
-    void shouldNotDetectSameVersion() {
-        assertFalse(UpdateChecker.isNewer("1.0.0", "1.0.0"));
-    }
+  @Test
+  void shouldNotDetectSameVersion() {
+    assertFalse(UpdateChecker.isNewer("1.0.0", "1.0.0"));
+  }
 
-    @Test
-    void shouldNotDetectOlderVersion() {
-        assertFalse(UpdateChecker.isNewer("1.0.0", "2.0.0"));
-    }
+  @Test
+  void shouldNotDetectOlderVersion() {
+    assertFalse(UpdateChecker.isNewer("1.0.0", "2.0.0"));
+  }
 
-    @Test
-    void shouldHandleDifferentLengthVersions() {
-        assertTrue(UpdateChecker.isNewer("1.0.0.1", "1.0.0"));
-        assertFalse(UpdateChecker.isNewer("1.0.0", "1.0.0.1"));
-    }
+  @Test
+  void shouldHandleDifferentLengthVersions() {
+    assertTrue(UpdateChecker.isNewer("1.0.0.1", "1.0.0"));
+    assertFalse(UpdateChecker.isNewer("1.0.0", "1.0.0.1"));
+  }
 
-    @Test
-    void shouldHandleTwoPartVersions() {
-        assertTrue(UpdateChecker.isNewer("1.1", "1.0"));
-        assertFalse(UpdateChecker.isNewer("1.0", "1.1"));
-    }
+  @Test
+  void shouldHandleTwoPartVersions() {
+    assertTrue(UpdateChecker.isNewer("1.1", "1.0"));
+    assertFalse(UpdateChecker.isNewer("1.0", "1.1"));
+  }
 }

--- a/src/test/java/br/com/nicomaia/server/commands/CommandResponseTest.java
+++ b/src/test/java/br/com/nicomaia/server/commands/CommandResponseTest.java
@@ -1,94 +1,96 @@
 package br.com.nicomaia.server.commands;
 
-import br.com.nicomaia.server.net.AddressType;
-import org.junit.jupiter.api.Test;
-
-import java.net.InetAddress;
-import java.net.Socket;
-
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import br.com.nicomaia.server.net.AddressType;
+import java.net.InetAddress;
+import java.net.Socket;
+import org.junit.jupiter.api.Test;
+
 class CommandResponseTest {
 
-    // Concrete subclass for testing the abstract class
-    private static class TestCommandResponse extends CommandResponse {
-        public TestCommandResponse(Command command, ResponseType responseType) {
-            super(command, responseType);
-        }
+  // Concrete subclass for testing the abstract class
+  private static class TestCommandResponse extends CommandResponse {
+    public TestCommandResponse(Command command, ResponseType responseType) {
+      super(command, responseType);
     }
+  }
 
-    @Test
-    void shouldBuildCorrectResponseBytesForIPv4() throws Exception {
-        InetAddress address = InetAddress.getByAddress(new byte[]{10, 0, 0, 1});
-        Command command = new Command((byte) 0x05, CommandType.CONNECT, AddressType.IPV4, address, 8080);
-        var response = new TestCommandResponse(command, ResponseType.SUCCEEDED);
+  @Test
+  void shouldBuildCorrectResponseBytesForIPv4() throws Exception {
+    InetAddress address = InetAddress.getByAddress(new byte[] {10, 0, 0, 1});
+    Command command =
+        new Command((byte) 0x05, CommandType.CONNECT, AddressType.IPV4, address, 8080);
+    var response = new TestCommandResponse(command, ResponseType.SUCCEEDED);
 
-        Socket client = mock(Socket.class);
-        when(client.getInetAddress()).thenReturn(InetAddress.getByAddress(new byte[]{(byte) 192, (byte) 168, 1, 1}));
-        when(client.getPort()).thenReturn(12345);
+    Socket client = mock(Socket.class);
+    when(client.getInetAddress())
+        .thenReturn(InetAddress.getByAddress(new byte[] {(byte) 192, (byte) 168, 1, 1}));
+    when(client.getPort()).thenReturn(12345);
 
-        byte[] bytes = response.getBytes(client);
+    byte[] bytes = response.getBytes(client);
 
-        // SOCKS version
-        assertEquals((byte) 0x05, bytes[0]);
-        // Response type (SUCCEEDED = 0x00)
-        assertEquals((byte) 0x00, bytes[1]);
-        // Reserved byte
-        assertEquals((byte) 0x00, bytes[2]);
-        // Address type (IPV4 = 0x01)
-        assertEquals((byte) 0x01, bytes[3]);
-        // Client IP: 192.168.1.1
-        assertEquals((byte) 192, bytes[4]);
-        assertEquals((byte) 168, bytes[5]);
-        assertEquals((byte) 1, bytes[6]);
-        assertEquals((byte) 1, bytes[7]);
-        // Port 12345: high byte = 48, low byte = 57
-        assertEquals((byte) 48, bytes[8]);
-        assertEquals((byte) 57, bytes[9]);
-    }
+    // SOCKS version
+    assertEquals((byte) 0x05, bytes[0]);
+    // Response type (SUCCEEDED = 0x00)
+    assertEquals((byte) 0x00, bytes[1]);
+    // Reserved byte
+    assertEquals((byte) 0x00, bytes[2]);
+    // Address type (IPV4 = 0x01)
+    assertEquals((byte) 0x01, bytes[3]);
+    // Client IP: 192.168.1.1
+    assertEquals((byte) 192, bytes[4]);
+    assertEquals((byte) 168, bytes[5]);
+    assertEquals((byte) 1, bytes[6]);
+    assertEquals((byte) 1, bytes[7]);
+    // Port 12345: high byte = 48, low byte = 57
+    assertEquals((byte) 48, bytes[8]);
+    assertEquals((byte) 57, bytes[9]);
+  }
 
-    @Test
-    void shouldBuildCorrectResponseBytesForDomainName() throws Exception {
-        InetAddress address = InetAddress.getByAddress(new byte[]{93, 0, 0, 1});
-        Command command = new Command((byte) 0x05, CommandType.CONNECT, AddressType.DOMAIN_NAME, address, 443);
-        var response = new TestCommandResponse(command, ResponseType.SUCCEEDED);
+  @Test
+  void shouldBuildCorrectResponseBytesForDomainName() throws Exception {
+    InetAddress address = InetAddress.getByAddress(new byte[] {93, 0, 0, 1});
+    Command command =
+        new Command((byte) 0x05, CommandType.CONNECT, AddressType.DOMAIN_NAME, address, 443);
+    var response = new TestCommandResponse(command, ResponseType.SUCCEEDED);
 
-        Socket client = mock(Socket.class);
-        when(client.getInetAddress()).thenReturn(InetAddress.getByAddress(new byte[]{10, 0, 0, 1}));
-        when(client.getPort()).thenReturn(443);
+    Socket client = mock(Socket.class);
+    when(client.getInetAddress()).thenReturn(InetAddress.getByAddress(new byte[] {10, 0, 0, 1}));
+    when(client.getPort()).thenReturn(443);
 
-        byte[] bytes = response.getBytes(client);
+    byte[] bytes = response.getBytes(client);
 
-        // SOCKS version
-        assertEquals((byte) 0x05, bytes[0]);
-        // Response type
-        assertEquals((byte) 0x00, bytes[1]);
-        // Reserved
-        assertEquals((byte) 0x00, bytes[2]);
-        // Address type (DOMAIN_NAME = 0x03)
-        assertEquals((byte) 0x03, bytes[3]);
-        // Domain length indicator (hardcoded 4 in implementation)
-        assertEquals((byte) 0x04, bytes[4]);
-    }
+    // SOCKS version
+    assertEquals((byte) 0x05, bytes[0]);
+    // Response type
+    assertEquals((byte) 0x00, bytes[1]);
+    // Reserved
+    assertEquals((byte) 0x00, bytes[2]);
+    // Address type (DOMAIN_NAME = 0x03)
+    assertEquals((byte) 0x03, bytes[3]);
+    // Domain length indicator (hardcoded 4 in implementation)
+    assertEquals((byte) 0x04, bytes[4]);
+  }
 
-    @Test
-    void shouldEncodePortCorrectly() throws Exception {
-        InetAddress address = InetAddress.getByAddress(new byte[]{127, 0, 0, 1});
-        Command command = new Command((byte) 0x05, CommandType.CONNECT, AddressType.IPV4, address, 80);
-        var response = new TestCommandResponse(command, ResponseType.SOCKS_SERVER_FAILURE);
+  @Test
+  void shouldEncodePortCorrectly() throws Exception {
+    InetAddress address = InetAddress.getByAddress(new byte[] {127, 0, 0, 1});
+    Command command = new Command((byte) 0x05, CommandType.CONNECT, AddressType.IPV4, address, 80);
+    var response = new TestCommandResponse(command, ResponseType.SOCKS_SERVER_FAILURE);
 
-        Socket client = mock(Socket.class);
-        when(client.getInetAddress()).thenReturn(address);
-        when(client.getPort()).thenReturn(443);
+    Socket client = mock(Socket.class);
+    when(client.getInetAddress()).thenReturn(address);
+    when(client.getPort()).thenReturn(443);
 
-        byte[] bytes = response.getBytes(client);
+    byte[] bytes = response.getBytes(client);
 
-        // Response type should be SOCKS_SERVER_FAILURE = 0x01
-        assertEquals((byte) 0x01, bytes[1]);
+    // Response type should be SOCKS_SERVER_FAILURE = 0x01
+    assertEquals((byte) 0x01, bytes[1]);
 
-        // Port 443: high = 1, low = 187
-        int port = ((bytes[bytes.length - 2] & 0xFF) << 8) | (bytes[bytes.length - 1] & 0xFF);
-        assertEquals(443, port);
-    }
+    // Port 443: high = 1, low = 187
+    int port = ((bytes[bytes.length - 2] & 0xFF) << 8) | (bytes[bytes.length - 1] & 0xFF);
+    assertEquals(443, port);
+  }
 }

--- a/src/test/java/br/com/nicomaia/server/commands/CommandTest.java
+++ b/src/test/java/br/com/nicomaia/server/commands/CommandTest.java
@@ -1,45 +1,44 @@
 package br.com.nicomaia.server.commands;
 
-import br.com.nicomaia.server.net.AddressType;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
+import br.com.nicomaia.server.net.AddressType;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 
 class CommandTest {
 
-    @Test
-    void shouldStoreAllFieldsViaRecordAccessors() throws UnknownHostException {
-        InetAddress address = InetAddress.getByAddress(new byte[]{127, 0, 0, 1});
-        var command = new Command((byte) 0x05, CommandType.CONNECT, AddressType.IPV4, address, 8080);
+  @Test
+  void shouldStoreAllFieldsViaRecordAccessors() throws UnknownHostException {
+    InetAddress address = InetAddress.getByAddress(new byte[] {127, 0, 0, 1});
+    var command = new Command((byte) 0x05, CommandType.CONNECT, AddressType.IPV4, address, 8080);
 
-        assertEquals((byte) 0x05, command.socksVersion());
-        assertEquals(CommandType.CONNECT, command.commandType());
-        assertEquals(AddressType.IPV4, command.addressType());
-        assertEquals(address, command.address());
-        assertEquals(8080, command.port());
-    }
+    assertEquals((byte) 0x05, command.socksVersion());
+    assertEquals(CommandType.CONNECT, command.commandType());
+    assertEquals(AddressType.IPV4, command.addressType());
+    assertEquals(address, command.address());
+    assertEquals(8080, command.port());
+  }
 
-    @Test
-    void shouldHaveEquality() throws UnknownHostException {
-        InetAddress address = InetAddress.getByAddress(new byte[]{10, 0, 0, 1});
-        var command1 = new Command((byte) 0x05, CommandType.CONNECT, AddressType.IPV4, address, 443);
-        var command2 = new Command((byte) 0x05, CommandType.CONNECT, AddressType.IPV4, address, 443);
+  @Test
+  void shouldHaveEquality() throws UnknownHostException {
+    InetAddress address = InetAddress.getByAddress(new byte[] {10, 0, 0, 1});
+    var command1 = new Command((byte) 0x05, CommandType.CONNECT, AddressType.IPV4, address, 443);
+    var command2 = new Command((byte) 0x05, CommandType.CONNECT, AddressType.IPV4, address, 443);
 
-        assertEquals(command1, command2);
-        assertEquals(command1.hashCode(), command2.hashCode());
-    }
+    assertEquals(command1, command2);
+    assertEquals(command1.hashCode(), command2.hashCode());
+  }
 
-    @Test
-    void shouldProduceToString() throws UnknownHostException {
-        InetAddress address = InetAddress.getByAddress(new byte[]{127, 0, 0, 1});
-        var command = new Command((byte) 0x05, CommandType.CONNECT, AddressType.IPV4, address, 80);
+  @Test
+  void shouldProduceToString() throws UnknownHostException {
+    InetAddress address = InetAddress.getByAddress(new byte[] {127, 0, 0, 1});
+    var command = new Command((byte) 0x05, CommandType.CONNECT, AddressType.IPV4, address, 80);
 
-        String str = command.toString();
-        assertNotNull(str);
-        assertTrue(str.contains("CONNECT"));
-        assertTrue(str.contains("IPV4"));
-    }
+    String str = command.toString();
+    assertNotNull(str);
+    assertTrue(str.contains("CONNECT"));
+    assertTrue(str.contains("IPV4"));
+  }
 }

--- a/src/test/java/br/com/nicomaia/server/commands/CommandTypeTest.java
+++ b/src/test/java/br/com/nicomaia/server/commands/CommandTypeTest.java
@@ -1,38 +1,39 @@
 package br.com.nicomaia.server.commands;
 
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.NoSuchElementException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
-import java.util.NoSuchElementException;
-
-import static org.junit.jupiter.api.Assertions.*;
-
 class CommandTypeTest {
 
-    @Test
-    void shouldResolveConnect() {
-        assertEquals(CommandType.CONNECT, CommandType.valueOf((byte) 0x01));
-    }
+  @Test
+  void shouldResolveConnect() {
+    assertEquals(CommandType.CONNECT, CommandType.valueOf((byte) 0x01));
+  }
 
-    @Test
-    void shouldResolveBind() {
-        assertEquals(CommandType.BIND, CommandType.valueOf((byte) 0x02));
-    }
+  @Test
+  void shouldResolveBind() {
+    assertEquals(CommandType.BIND, CommandType.valueOf((byte) 0x02));
+  }
 
-    @Test
-    void shouldResolveUdpAssociate() {
-        assertEquals(CommandType.UDP_ASSOCIATE, CommandType.valueOf((byte) 0x03));
-    }
+  @Test
+  void shouldResolveUdpAssociate() {
+    assertEquals(CommandType.UDP_ASSOCIATE, CommandType.valueOf((byte) 0x03));
+  }
 
-    @Test
-    void shouldThrowForUnknownCommandType() {
-        assertThrows(NoSuchElementException.class, () -> CommandType.valueOf((byte) 0xFF));
-    }
+  @Test
+  void shouldThrowForUnknownCommandType() {
+    assertThrows(NoSuchElementException.class, () -> CommandType.valueOf((byte) 0xFF));
+  }
 
-    @ParameterizedTest
-    @EnumSource(value = CommandType.class, names = {"CONNECT", "BIND", "UDP_ASSOCIATE"})
-    void shouldRoundTripByteToEnum(CommandType type) {
-        assertEquals(type, CommandType.valueOf(type.getNumber()));
-    }
+  @ParameterizedTest
+  @EnumSource(
+      value = CommandType.class,
+      names = {"CONNECT", "BIND", "UDP_ASSOCIATE"})
+  void shouldRoundTripByteToEnum(CommandType type) {
+    assertEquals(type, CommandType.valueOf(type.getNumber()));
+  }
 }

--- a/src/test/java/br/com/nicomaia/server/commands/ResponseTypeTest.java
+++ b/src/test/java/br/com/nicomaia/server/commands/ResponseTypeTest.java
@@ -1,49 +1,48 @@
 package br.com.nicomaia.server.commands;
 
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.NoSuchElementException;
-
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 
 class ResponseTypeTest {
 
-    @Test
-    void shouldResolveSucceeded() {
-        assertEquals(ResponseType.SUCCEEDED, ResponseType.valueOf((byte) 0x00));
-    }
+  @Test
+  void shouldResolveSucceeded() {
+    assertEquals(ResponseType.SUCCEEDED, ResponseType.valueOf((byte) 0x00));
+  }
 
-    @Test
-    void shouldResolveServerFailure() {
-        assertEquals(ResponseType.SOCKS_SERVER_FAILURE, ResponseType.valueOf((byte) 0x01));
-    }
+  @Test
+  void shouldResolveServerFailure() {
+    assertEquals(ResponseType.SOCKS_SERVER_FAILURE, ResponseType.valueOf((byte) 0x01));
+  }
 
-    @Test
-    void shouldResolveConnectionRefused() {
-        assertEquals(ResponseType.CONNECTION_REFUSED, ResponseType.valueOf((byte) 0x05));
-    }
+  @Test
+  void shouldResolveConnectionRefused() {
+    assertEquals(ResponseType.CONNECTION_REFUSED, ResponseType.valueOf((byte) 0x05));
+  }
 
-    @Test
-    void shouldResolveCommandNotSupported() {
-        assertEquals(ResponseType.COMMAND_NOT_SUPPORTED, ResponseType.valueOf((byte) 0x07));
-    }
+  @Test
+  void shouldResolveCommandNotSupported() {
+    assertEquals(ResponseType.COMMAND_NOT_SUPPORTED, ResponseType.valueOf((byte) 0x07));
+  }
 
-    @Test
-    void shouldThrowForUnknownResponseType() {
-        assertThrows(NoSuchElementException.class, () -> ResponseType.valueOf((byte) 0xFF));
-    }
+  @Test
+  void shouldThrowForUnknownResponseType() {
+    assertThrows(NoSuchElementException.class, () -> ResponseType.valueOf((byte) 0xFF));
+  }
 
-    @Test
-    void shouldHaveCorrectByteValues() {
-        assertEquals((byte) 0x00, ResponseType.SUCCEEDED.getNumber());
-        assertEquals((byte) 0x01, ResponseType.SOCKS_SERVER_FAILURE.getNumber());
-        assertEquals((byte) 0x02, ResponseType.CONNECTION_NOT_ALLOWED.getNumber());
-        assertEquals((byte) 0x03, ResponseType.NETWORK_UNREACHABLE.getNumber());
-        assertEquals((byte) 0x04, ResponseType.HOST_UNREACHABLE.getNumber());
-        assertEquals((byte) 0x05, ResponseType.CONNECTION_REFUSED.getNumber());
-        assertEquals((byte) 0x06, ResponseType.TTL_EXPIRED.getNumber());
-        assertEquals((byte) 0x07, ResponseType.COMMAND_NOT_SUPPORTED.getNumber());
-        assertEquals((byte) 0x08, ResponseType.ADDRESS_TYPE_NOT_SUPPORTED.getNumber());
-        assertEquals((byte) 0x09, ResponseType.UNASSIGNED.getNumber());
-    }
+  @Test
+  void shouldHaveCorrectByteValues() {
+    assertEquals((byte) 0x00, ResponseType.SUCCEEDED.getNumber());
+    assertEquals((byte) 0x01, ResponseType.SOCKS_SERVER_FAILURE.getNumber());
+    assertEquals((byte) 0x02, ResponseType.CONNECTION_NOT_ALLOWED.getNumber());
+    assertEquals((byte) 0x03, ResponseType.NETWORK_UNREACHABLE.getNumber());
+    assertEquals((byte) 0x04, ResponseType.HOST_UNREACHABLE.getNumber());
+    assertEquals((byte) 0x05, ResponseType.CONNECTION_REFUSED.getNumber());
+    assertEquals((byte) 0x06, ResponseType.TTL_EXPIRED.getNumber());
+    assertEquals((byte) 0x07, ResponseType.COMMAND_NOT_SUPPORTED.getNumber());
+    assertEquals((byte) 0x08, ResponseType.ADDRESS_TYPE_NOT_SUPPORTED.getNumber());
+    assertEquals((byte) 0x09, ResponseType.UNASSIGNED.getNumber());
+  }
 }

--- a/src/test/java/br/com/nicomaia/server/commands/handlers/HandlersHolderTest.java
+++ b/src/test/java/br/com/nicomaia/server/commands/handlers/HandlersHolderTest.java
@@ -1,52 +1,52 @@
 package br.com.nicomaia.server.commands.handlers;
 
-import br.com.nicomaia.server.commands.CommandType;
-import org.junit.jupiter.api.Test;
-
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 
+import br.com.nicomaia.server.commands.CommandType;
+import org.junit.jupiter.api.Test;
+
 class HandlersHolderTest {
 
-    @Test
-    void shouldRegisterAndRetrieveHandler() {
-        HandlersHolder holder = new HandlersHolder();
-        CommandHandler handler = mock(CommandHandler.class);
+  @Test
+  void shouldRegisterAndRetrieveHandler() {
+    HandlersHolder holder = new HandlersHolder();
+    CommandHandler handler = mock(CommandHandler.class);
 
-        holder.register(CommandType.CONNECT, handler);
+    holder.register(CommandType.CONNECT, handler);
 
-        assertSame(handler, holder.get(CommandType.CONNECT));
-    }
+    assertSame(handler, holder.get(CommandType.CONNECT));
+  }
 
-    @Test
-    void shouldReturnNullForUnregisteredType() {
-        HandlersHolder holder = new HandlersHolder();
+  @Test
+  void shouldReturnNullForUnregisteredType() {
+    HandlersHolder holder = new HandlersHolder();
 
-        assertNull(holder.get(CommandType.BIND));
-    }
+    assertNull(holder.get(CommandType.BIND));
+  }
 
-    @Test
-    void shouldOverwriteExistingHandler() {
-        HandlersHolder holder = new HandlersHolder();
-        CommandHandler first = mock(CommandHandler.class);
-        CommandHandler second = mock(CommandHandler.class);
+  @Test
+  void shouldOverwriteExistingHandler() {
+    HandlersHolder holder = new HandlersHolder();
+    CommandHandler first = mock(CommandHandler.class);
+    CommandHandler second = mock(CommandHandler.class);
 
-        holder.register(CommandType.CONNECT, first);
-        holder.register(CommandType.CONNECT, second);
+    holder.register(CommandType.CONNECT, first);
+    holder.register(CommandType.CONNECT, second);
 
-        assertSame(second, holder.get(CommandType.CONNECT));
-    }
+    assertSame(second, holder.get(CommandType.CONNECT));
+  }
 
-    @Test
-    void shouldSupportMultipleCommandTypes() {
-        HandlersHolder holder = new HandlersHolder();
-        CommandHandler connectHandler = mock(CommandHandler.class);
-        CommandHandler bindHandler = mock(CommandHandler.class);
+  @Test
+  void shouldSupportMultipleCommandTypes() {
+    HandlersHolder holder = new HandlersHolder();
+    CommandHandler connectHandler = mock(CommandHandler.class);
+    CommandHandler bindHandler = mock(CommandHandler.class);
 
-        holder.register(CommandType.CONNECT, connectHandler);
-        holder.register(CommandType.BIND, bindHandler);
+    holder.register(CommandType.CONNECT, connectHandler);
+    holder.register(CommandType.BIND, bindHandler);
 
-        assertSame(connectHandler, holder.get(CommandType.CONNECT));
-        assertSame(bindHandler, holder.get(CommandType.BIND));
-    }
+    assertSame(connectHandler, holder.get(CommandType.CONNECT));
+    assertSame(bindHandler, holder.get(CommandType.BIND));
+  }
 }

--- a/src/test/java/br/com/nicomaia/server/net/AddressResolverTest.java
+++ b/src/test/java/br/com/nicomaia/server/net/AddressResolverTest.java
@@ -1,88 +1,87 @@
 package br.com.nicomaia.server.net;
 
-import br.com.nicomaia.server.net.resolvers.InetResolver;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
+import br.com.nicomaia.server.net.resolvers.InetResolver;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.HashMap;
 import java.util.Map;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import org.junit.jupiter.api.Test;
 
 class AddressResolverTest {
 
-    @Test
-    void shouldResolveIPv4Address() throws Exception {
-        InetAddress expected = InetAddress.getByAddress(new byte[]{10, 0, 0, 1});
-        InetResolver ipResolver = mock(InetResolver.class);
-        Address address = new Address(new byte[]{10, 0, 0, 1}, AddressType.IPV4);
+  @Test
+  void shouldResolveIPv4Address() throws Exception {
+    InetAddress expected = InetAddress.getByAddress(new byte[] {10, 0, 0, 1});
+    InetResolver ipResolver = mock(InetResolver.class);
+    Address address = new Address(new byte[] {10, 0, 0, 1}, AddressType.IPV4);
 
-        when(ipResolver.resolve(address)).thenReturn(expected);
+    when(ipResolver.resolve(address)).thenReturn(expected);
 
-        Map<AddressType, InetResolver> resolvers = Map.of(AddressType.IPV4, ipResolver);
-        AddressResolver resolver = new AddressResolver(resolvers);
+    Map<AddressType, InetResolver> resolvers = Map.of(AddressType.IPV4, ipResolver);
+    AddressResolver resolver = new AddressResolver(resolvers);
 
-        InetAddress result = resolver.resolve(address);
+    InetAddress result = resolver.resolve(address);
 
-        assertEquals(expected, result);
-        verify(ipResolver).resolve(address);
-    }
+    assertEquals(expected, result);
+    verify(ipResolver).resolve(address);
+  }
 
-    @Test
-    void shouldResolveIPv6Address() throws Exception {
-        byte[] ipv6Bytes = new byte[16];
-        ipv6Bytes[15] = 1;
-        InetAddress expected = InetAddress.getByAddress(ipv6Bytes);
-        InetResolver ipResolver = mock(InetResolver.class);
-        Address address = new Address(ipv6Bytes, AddressType.IPV6);
+  @Test
+  void shouldResolveIPv6Address() throws Exception {
+    byte[] ipv6Bytes = new byte[16];
+    ipv6Bytes[15] = 1;
+    InetAddress expected = InetAddress.getByAddress(ipv6Bytes);
+    InetResolver ipResolver = mock(InetResolver.class);
+    Address address = new Address(ipv6Bytes, AddressType.IPV6);
 
-        when(ipResolver.resolve(address)).thenReturn(expected);
+    when(ipResolver.resolve(address)).thenReturn(expected);
 
-        Map<AddressType, InetResolver> resolvers = Map.of(AddressType.IPV6, ipResolver);
-        AddressResolver resolver = new AddressResolver(resolvers);
+    Map<AddressType, InetResolver> resolvers = Map.of(AddressType.IPV6, ipResolver);
+    AddressResolver resolver = new AddressResolver(resolvers);
 
-        InetAddress result = resolver.resolve(address);
+    InetAddress result = resolver.resolve(address);
 
-        assertEquals(expected, result);
-    }
+    assertEquals(expected, result);
+  }
 
-    @Test
-    void shouldResolveDomainAddress() throws Exception {
-        InetAddress expected = InetAddress.getByAddress(new byte[]{93, 0, 0, 1});
-        InetResolver domainResolver = mock(InetResolver.class);
-        Address address = new Address("example.com".getBytes(), AddressType.DOMAIN_NAME);
+  @Test
+  void shouldResolveDomainAddress() throws Exception {
+    InetAddress expected = InetAddress.getByAddress(new byte[] {93, 0, 0, 1});
+    InetResolver domainResolver = mock(InetResolver.class);
+    Address address = new Address("example.com".getBytes(), AddressType.DOMAIN_NAME);
 
-        when(domainResolver.resolve(address)).thenReturn(expected);
+    when(domainResolver.resolve(address)).thenReturn(expected);
 
-        Map<AddressType, InetResolver> resolvers = Map.of(AddressType.DOMAIN_NAME, domainResolver);
-        AddressResolver resolver = new AddressResolver(resolvers);
+    Map<AddressType, InetResolver> resolvers = Map.of(AddressType.DOMAIN_NAME, domainResolver);
+    AddressResolver resolver = new AddressResolver(resolvers);
 
-        InetAddress result = resolver.resolve(address);
+    InetAddress result = resolver.resolve(address);
 
-        assertEquals(expected, result);
-    }
+    assertEquals(expected, result);
+  }
 
-    @Test
-    void shouldThrowResolverNotFoundForUnregisteredType() {
-        Map<AddressType, InetResolver> resolvers = new HashMap<>();
-        AddressResolver resolver = new AddressResolver(resolvers);
-        Address address = new Address(new byte[]{127, 0, 0, 1}, AddressType.IPV4);
+  @Test
+  void shouldThrowResolverNotFoundForUnregisteredType() {
+    Map<AddressType, InetResolver> resolvers = new HashMap<>();
+    AddressResolver resolver = new AddressResolver(resolvers);
+    Address address = new Address(new byte[] {127, 0, 0, 1}, AddressType.IPV4);
 
-        assertThrows(ResolverNotFoundException.class, () -> resolver.resolve(address));
-    }
+    assertThrows(ResolverNotFoundException.class, () -> resolver.resolve(address));
+  }
 
-    @Test
-    void shouldPropagateUnknownHostException() throws Exception {
-        InetResolver resolver = mock(InetResolver.class);
-        Address address = new Address("invalid.host".getBytes(), AddressType.DOMAIN_NAME);
+  @Test
+  void shouldPropagateUnknownHostException() throws Exception {
+    InetResolver resolver = mock(InetResolver.class);
+    Address address = new Address("invalid.host".getBytes(), AddressType.DOMAIN_NAME);
 
-        when(resolver.resolve(address)).thenThrow(new UnknownHostException("not found"));
+    when(resolver.resolve(address)).thenThrow(new UnknownHostException("not found"));
 
-        Map<AddressType, InetResolver> resolvers = Map.of(AddressType.DOMAIN_NAME, resolver);
-        AddressResolver addressResolver = new AddressResolver(resolvers);
+    Map<AddressType, InetResolver> resolvers = Map.of(AddressType.DOMAIN_NAME, resolver);
+    AddressResolver addressResolver = new AddressResolver(resolvers);
 
-        assertThrows(UnknownHostException.class, () -> addressResolver.resolve(address));
-    }
+    assertThrows(UnknownHostException.class, () -> addressResolver.resolve(address));
+  }
 }

--- a/src/test/java/br/com/nicomaia/server/net/AddressTest.java
+++ b/src/test/java/br/com/nicomaia/server/net/AddressTest.java
@@ -1,36 +1,36 @@
 package br.com.nicomaia.server.net;
 
-import org.junit.jupiter.api.Test;
-
 import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
 
 class AddressTest {
 
-    @Test
-    void shouldStoreContentAndType() {
-        byte[] content = {127, 0, 0, 1};
-        var address = new Address(content, AddressType.IPV4);
+  @Test
+  void shouldStoreContentAndType() {
+    byte[] content = {127, 0, 0, 1};
+    var address = new Address(content, AddressType.IPV4);
 
-        assertArrayEquals(content, address.content());
-        assertEquals(AddressType.IPV4, address.addressType());
-    }
+    assertArrayEquals(content, address.content());
+    assertEquals(AddressType.IPV4, address.addressType());
+  }
 
-    @Test
-    void shouldStoreDomainAddress() {
-        byte[] content = "example.com".getBytes();
-        var address = new Address(content, AddressType.DOMAIN_NAME);
+  @Test
+  void shouldStoreDomainAddress() {
+    byte[] content = "example.com".getBytes();
+    var address = new Address(content, AddressType.DOMAIN_NAME);
 
-        assertEquals("example.com", new String(address.content()));
-        assertEquals(AddressType.DOMAIN_NAME, address.addressType());
-    }
+    assertEquals("example.com", new String(address.content()));
+    assertEquals(AddressType.DOMAIN_NAME, address.addressType());
+  }
 
-    @Test
-    void shouldStoreIPv6Address() {
-        byte[] content = new byte[16];
-        content[15] = 1; // ::1
-        var address = new Address(content, AddressType.IPV6);
+  @Test
+  void shouldStoreIPv6Address() {
+    byte[] content = new byte[16];
+    content[15] = 1; // ::1
+    var address = new Address(content, AddressType.IPV6);
 
-        assertEquals(16, address.content().length);
-        assertEquals(AddressType.IPV6, address.addressType());
-    }
+    assertEquals(16, address.content().length);
+    assertEquals(AddressType.IPV6, address.addressType());
+  }
 }

--- a/src/test/java/br/com/nicomaia/server/net/AddressTypeTest.java
+++ b/src/test/java/br/com/nicomaia/server/net/AddressTypeTest.java
@@ -1,44 +1,42 @@
 package br.com.nicomaia.server.net;
 
-import org.junit.jupiter.api.Test;
-
-import java.util.NoSuchElementException;
-
 import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
 
 class AddressTypeTest {
 
-    @Test
-    void shouldResolveIPv4() {
-        assertEquals(AddressType.IPV4, AddressType.valueOf((byte) 0x01));
-    }
+  @Test
+  void shouldResolveIPv4() {
+    assertEquals(AddressType.IPV4, AddressType.valueOf((byte) 0x01));
+  }
 
-    @Test
-    void shouldResolveDomainName() {
-        assertEquals(AddressType.DOMAIN_NAME, AddressType.valueOf((byte) 0x03));
-    }
+  @Test
+  void shouldResolveDomainName() {
+    assertEquals(AddressType.DOMAIN_NAME, AddressType.valueOf((byte) 0x03));
+  }
 
-    @Test
-    void shouldResolveIPv6() {
-        assertEquals(AddressType.IPV6, AddressType.valueOf((byte) 0x04));
-    }
+  @Test
+  void shouldResolveIPv6() {
+    assertEquals(AddressType.IPV6, AddressType.valueOf((byte) 0x04));
+  }
 
-    @Test
-    void shouldThrowForUnknownAddressType() {
-        assertThrows(IllegalArgumentException.class, () -> AddressType.valueOf((byte) 0xFF));
-    }
+  @Test
+  void shouldThrowForUnknownAddressType() {
+    assertThrows(IllegalArgumentException.class, () -> AddressType.valueOf((byte) 0xFF));
+  }
 
-    @Test
-    void shouldReturnCorrectTypeCodes() {
-        assertEquals((byte) 0x01, AddressType.IPV4.getTypeCode());
-        assertEquals((byte) 0x03, AddressType.DOMAIN_NAME.getTypeCode());
-        assertEquals((byte) 0x04, AddressType.IPV6.getTypeCode());
-    }
+  @Test
+  void shouldReturnCorrectTypeCodes() {
+    assertEquals((byte) 0x01, AddressType.IPV4.getTypeCode());
+    assertEquals((byte) 0x03, AddressType.DOMAIN_NAME.getTypeCode());
+    assertEquals((byte) 0x04, AddressType.IPV6.getTypeCode());
+  }
 
-    @Test
-    void shouldRoundTripAllValues() {
-        for (AddressType type : AddressType.values()) {
-            assertEquals(type, AddressType.valueOf(type.getTypeCode()));
-        }
+  @Test
+  void shouldRoundTripAllValues() {
+    for (AddressType type : AddressType.values()) {
+      assertEquals(type, AddressType.valueOf(type.getTypeCode()));
     }
+  }
 }

--- a/src/test/java/br/com/nicomaia/server/net/resolvers/IpInetResolverTest.java
+++ b/src/test/java/br/com/nicomaia/server/net/resolvers/IpInetResolverTest.java
@@ -1,45 +1,44 @@
 package br.com.nicomaia.server.net.resolvers;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 import br.com.nicomaia.server.net.Address;
 import br.com.nicomaia.server.net.AddressType;
-import org.junit.jupiter.api.Test;
-
 import java.net.InetAddress;
-
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 
 class IpInetResolverTest {
 
-    private final IpInetResolver resolver = new IpInetResolver();
+  private final IpInetResolver resolver = new IpInetResolver();
 
-    @Test
-    void shouldResolveIPv4Address() throws Exception {
-        byte[] ipBytes = {127, 0, 0, 1};
-        Address address = new Address(ipBytes, AddressType.IPV4);
+  @Test
+  void shouldResolveIPv4Address() throws Exception {
+    byte[] ipBytes = {127, 0, 0, 1};
+    Address address = new Address(ipBytes, AddressType.IPV4);
 
-        InetAddress result = resolver.resolve(address);
+    InetAddress result = resolver.resolve(address);
 
-        assertArrayEquals(ipBytes, result.getAddress());
-    }
+    assertArrayEquals(ipBytes, result.getAddress());
+  }
 
-    @Test
-    void shouldResolveIPv6Address() throws Exception {
-        byte[] ipv6Bytes = new byte[16];
-        ipv6Bytes[15] = 1; // ::1
-        Address address = new Address(ipv6Bytes, AddressType.IPV6);
+  @Test
+  void shouldResolveIPv6Address() throws Exception {
+    byte[] ipv6Bytes = new byte[16];
+    ipv6Bytes[15] = 1; // ::1
+    Address address = new Address(ipv6Bytes, AddressType.IPV6);
 
-        InetAddress result = resolver.resolve(address);
+    InetAddress result = resolver.resolve(address);
 
-        assertArrayEquals(ipv6Bytes, result.getAddress());
-    }
+    assertArrayEquals(ipv6Bytes, result.getAddress());
+  }
 
-    @Test
-    void shouldResolvePrivateNetworkAddress() throws Exception {
-        byte[] ipBytes = {10, 0, 0, 1};
-        Address address = new Address(ipBytes, AddressType.IPV4);
+  @Test
+  void shouldResolvePrivateNetworkAddress() throws Exception {
+    byte[] ipBytes = {10, 0, 0, 1};
+    Address address = new Address(ipBytes, AddressType.IPV4);
 
-        InetAddress result = resolver.resolve(address);
+    InetAddress result = resolver.resolve(address);
 
-        assertEquals("/10.0.0.1", result.toString());
-    }
+    assertEquals("/10.0.0.1", result.toString());
+  }
 }

--- a/src/test/java/br/com/nicomaia/server/protocol/AuthRequestTest.java
+++ b/src/test/java/br/com/nicomaia/server/protocol/AuthRequestTest.java
@@ -1,30 +1,30 @@
 package br.com.nicomaia.server.protocol;
 
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Set;
-
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 
 class AuthRequestTest {
 
-    @Test
-    void shouldStoreAllFields() {
-        Set<SupportedAuthType> authTypes = Set.of(SupportedAuthType.NO_AUTH);
-        var request = new AuthRequest((byte) 0x05, (byte) 0x01, authTypes);
+  @Test
+  void shouldStoreAllFields() {
+    Set<SupportedAuthType> authTypes = Set.of(SupportedAuthType.NO_AUTH);
+    var request = new AuthRequest((byte) 0x05, (byte) 0x01, authTypes);
 
-        assertEquals((byte) 0x05, request.socksVersion());
-        assertEquals((byte) 0x01, request.availableClientAuthTypes());
-        assertEquals(authTypes, request.supportedAuthTypes());
-    }
+    assertEquals((byte) 0x05, request.socksVersion());
+    assertEquals((byte) 0x01, request.availableClientAuthTypes());
+    assertEquals(authTypes, request.supportedAuthTypes());
+  }
 
-    @Test
-    void shouldProduceReadableToString() {
-        Set<SupportedAuthType> authTypes = Set.of(SupportedAuthType.NO_AUTH, SupportedAuthType.USERNAME);
-        var request = new AuthRequest((byte) 0x05, (byte) 0x02, authTypes);
+  @Test
+  void shouldProduceReadableToString() {
+    Set<SupportedAuthType> authTypes =
+        Set.of(SupportedAuthType.NO_AUTH, SupportedAuthType.USERNAME);
+    var request = new AuthRequest((byte) 0x05, (byte) 0x02, authTypes);
 
-        String result = request.toString();
-        assertTrue(result.contains("AuthRequest"));
-        assertTrue(result.contains("socksVersion=5"));
-    }
+    String result = request.toString();
+    assertTrue(result.contains("AuthRequest"));
+    assertTrue(result.contains("socksVersion=5"));
+  }
 }

--- a/src/test/java/br/com/nicomaia/server/protocol/AuthResponseTest.java
+++ b/src/test/java/br/com/nicomaia/server/protocol/AuthResponseTest.java
@@ -1,46 +1,46 @@
 package br.com.nicomaia.server.protocol;
 
-import org.junit.jupiter.api.Test;
-
 import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
 
 class AuthResponseTest {
 
-    @Test
-    void shouldStoreFields() {
-        var response = new AuthResponse((byte) 0x05, SupportedAuthType.NO_AUTH);
+  @Test
+  void shouldStoreFields() {
+    var response = new AuthResponse((byte) 0x05, SupportedAuthType.NO_AUTH);
 
-        assertEquals((byte) 0x05, response.socksVersion());
-        assertEquals(SupportedAuthType.NO_AUTH, response.chosenAuthMethod());
-    }
+    assertEquals((byte) 0x05, response.socksVersion());
+    assertEquals(SupportedAuthType.NO_AUTH, response.chosenAuthMethod());
+  }
 
-    @Test
-    void shouldBuildCorrectResponse() {
-        var response = new AuthResponse((byte) 0x05, SupportedAuthType.NO_AUTH);
-        byte[] bytes = response.toBytes();
+  @Test
+  void shouldBuildCorrectResponse() {
+    var response = new AuthResponse((byte) 0x05, SupportedAuthType.NO_AUTH);
+    byte[] bytes = response.toBytes();
 
-        assertEquals(2, bytes.length);
-        assertEquals((byte) 0x05, bytes[0]);
-        assertEquals((byte) 0x00, bytes[1]);
-    }
+    assertEquals(2, bytes.length);
+    assertEquals((byte) 0x05, bytes[0]);
+    assertEquals((byte) 0x00, bytes[1]);
+  }
 
-    @Test
-    void shouldBuildResponseWithUsernameAuth() {
-        var response = new AuthResponse((byte) 0x05, SupportedAuthType.USERNAME);
-        byte[] bytes = response.toBytes();
+  @Test
+  void shouldBuildResponseWithUsernameAuth() {
+    var response = new AuthResponse((byte) 0x05, SupportedAuthType.USERNAME);
+    byte[] bytes = response.toBytes();
 
-        assertEquals(2, bytes.length);
-        assertEquals((byte) 0x05, bytes[0]);
-        assertEquals((byte) 0x02, bytes[1]);
-    }
+    assertEquals(2, bytes.length);
+    assertEquals((byte) 0x05, bytes[0]);
+    assertEquals((byte) 0x02, bytes[1]);
+  }
 
-    @Test
-    void shouldProduceReadableToString() {
-        var response = new AuthResponse((byte) 0x05, SupportedAuthType.NO_AUTH);
-        String str = response.toString();
+  @Test
+  void shouldProduceReadableToString() {
+    var response = new AuthResponse((byte) 0x05, SupportedAuthType.NO_AUTH);
+    String str = response.toString();
 
-        assertTrue(str.contains("AuthResponse"));
-        assertTrue(str.contains("socksVersion=5"));
-        assertTrue(str.contains("NO_AUTH"));
-    }
+    assertTrue(str.contains("AuthResponse"));
+    assertTrue(str.contains("socksVersion=5"));
+    assertTrue(str.contains("NO_AUTH"));
+  }
 }

--- a/src/test/java/br/com/nicomaia/server/protocol/SupportedAuthTypeTest.java
+++ b/src/test/java/br/com/nicomaia/server/protocol/SupportedAuthTypeTest.java
@@ -1,64 +1,63 @@
 package br.com.nicomaia.server.protocol;
 
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Set;
-
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 
 class SupportedAuthTypeTest {
 
-    @Test
-    void shouldReturnNoAuthForByte0x00() {
-        assertEquals((byte) 0x00, SupportedAuthType.NO_AUTH.getNumber());
-    }
+  @Test
+  void shouldReturnNoAuthForByte0x00() {
+    assertEquals((byte) 0x00, SupportedAuthType.NO_AUTH.getNumber());
+  }
 
-    @Test
-    void shouldReturnUsernameForByte0x02() {
-        assertEquals((byte) 0x02, SupportedAuthType.USERNAME.getNumber());
-    }
+  @Test
+  void shouldReturnUsernameForByte0x02() {
+    assertEquals((byte) 0x02, SupportedAuthType.USERNAME.getNumber());
+  }
 
-    @Test
-    void shouldParseValidAuthTypesFromByteArray() {
-        byte[] buffer = {0x00, 0x02};
-        Set<SupportedAuthType> result = SupportedAuthType.valueOf(buffer);
+  @Test
+  void shouldParseValidAuthTypesFromByteArray() {
+    byte[] buffer = {0x00, 0x02};
+    Set<SupportedAuthType> result = SupportedAuthType.valueOf(buffer);
 
-        assertEquals(2, result.size());
-        assertTrue(result.contains(SupportedAuthType.NO_AUTH));
-        assertTrue(result.contains(SupportedAuthType.USERNAME));
-    }
+    assertEquals(2, result.size());
+    assertTrue(result.contains(SupportedAuthType.NO_AUTH));
+    assertTrue(result.contains(SupportedAuthType.USERNAME));
+  }
 
-    @Test
-    void shouldIgnoreUnknownAuthTypes() {
-        byte[] buffer = {0x00, 0x05, 0x02};
-        Set<SupportedAuthType> result = SupportedAuthType.valueOf(buffer);
+  @Test
+  void shouldIgnoreUnknownAuthTypes() {
+    byte[] buffer = {0x00, 0x05, 0x02};
+    Set<SupportedAuthType> result = SupportedAuthType.valueOf(buffer);
 
-        assertEquals(2, result.size());
-        assertTrue(result.contains(SupportedAuthType.NO_AUTH));
-        assertTrue(result.contains(SupportedAuthType.USERNAME));
-    }
+    assertEquals(2, result.size());
+    assertTrue(result.contains(SupportedAuthType.NO_AUTH));
+    assertTrue(result.contains(SupportedAuthType.USERNAME));
+  }
 
-    @Test
-    void shouldReturnEmptySetWhenNoKnownAuthTypes() {
-        byte[] buffer = {0x05, 0x06};
-        Set<SupportedAuthType> result = SupportedAuthType.valueOf(buffer);
+  @Test
+  void shouldReturnEmptySetWhenNoKnownAuthTypes() {
+    byte[] buffer = {0x05, 0x06};
+    Set<SupportedAuthType> result = SupportedAuthType.valueOf(buffer);
 
-        assertTrue(result.isEmpty());
-    }
+    assertTrue(result.isEmpty());
+  }
 
-    @Test
-    void shouldReturnEmptySetForEmptyBuffer() {
-        byte[] buffer = {};
-        Set<SupportedAuthType> result = SupportedAuthType.valueOf(buffer);
+  @Test
+  void shouldReturnEmptySetForEmptyBuffer() {
+    byte[] buffer = {};
+    Set<SupportedAuthType> result = SupportedAuthType.valueOf(buffer);
 
-        assertTrue(result.isEmpty());
-    }
+    assertTrue(result.isEmpty());
+  }
 
-    @Test
-    void shouldHandleDuplicateAuthTypesInBuffer() {
-        byte[] buffer = {0x00, 0x00, 0x02};
-        Set<SupportedAuthType> result = SupportedAuthType.valueOf(buffer);
+  @Test
+  void shouldHandleDuplicateAuthTypesInBuffer() {
+    byte[] buffer = {0x00, 0x00, 0x02};
+    Set<SupportedAuthType> result = SupportedAuthType.valueOf(buffer);
 
-        assertEquals(2, result.size());
-    }
+    assertEquals(2, result.size());
+  }
 }


### PR DESCRIPTION
Applies [google-java-format v1.35.0](https://github.com/google/google-java-format) to all 39 Java files (src + test).

### Changes
- Indentation: 4 spaces → 2 spaces (Google Style)
- Line breaks at ~100 columns
- Import ordering standardized

### Verification
- ✅ 60 unit tests passing
- No logic changes — purely cosmetic