### PR TITLE
fix: remaining code smells - unsafe valueOf, System.out, RuntimeException

### DIFF
--- a/src/main/java/br/com/nicomaia/server/UpdateChecker.java
+++ b/src/main/java/br/com/nicomaia/server/UpdateChecker.java
@@ -5,8 +5,11 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
+import java.util.logging.Logger;
 
 public class UpdateChecker {
+
+  private static final Logger logger = Logger.getLogger(UpdateChecker.class.getName());
 
   private static final String CURRENT_VERSION = loadVersion();
   private static final String GITHUB_REPO = "josenicomaia/socks-server";
@@ -35,22 +38,20 @@ public class UpdateChecker {
               try {
                 String latestVersion = fetchLatestVersion();
                 if (latestVersion != null && isNewer(latestVersion, CURRENT_VERSION)) {
-                  System.out.println();
-                  System.out.println(
-                      "╔════════════════════════════════════════════════════════════╗");
-                  System.out.println(
-                      "║  A new version of socks-server is available: "
+                  logger.info(
+                      "\n"
+                          + "╔════════════════════════════════════════════════════════════╗\n"
+                          + "║  A new version of socks-server is available: "
                           + padRight(latestVersion, 13)
-                          + "║");
-                  System.out.println(
-                      "║  You are running version: " + padRight(CURRENT_VERSION, 33) + "║");
-                  System.out.println(
-                      "║                                                            ║");
-                  System.out.println(
-                      "║  https://github.com/" + padRight(GITHUB_REPO + "/releases", 39) + "║");
-                  System.out.println(
-                      "╚════════════════════════════════════════════════════════════╝");
-                  System.out.println();
+                          + "║\n"
+                          + "║  You are running version: "
+                          + padRight(CURRENT_VERSION, 33)
+                          + "║\n"
+                          + "║                                                            ║\n"
+                          + "║  https://github.com/"
+                          + padRight(GITHUB_REPO + "/releases", 39)
+                          + "║\n"
+                          + "╚════════════════════════════════════════════════════════════╝");
                 }
               } catch (Exception ignored) {
                 // Silently fail — update check should never block or crash the app

--- a/src/main/java/br/com/nicomaia/server/commands/ResponseType.java
+++ b/src/main/java/br/com/nicomaia/server/commands/ResponseType.java
@@ -28,6 +28,9 @@ public enum ResponseType {
     return Arrays.stream(values())
         .filter(commandType -> commandType.number == number)
         .findFirst()
-        .get();
+        .orElseThrow(
+            () ->
+                new IllegalArgumentException(
+                    "Unknown response type: 0x" + String.format("%02X", number)));
   }
 }

--- a/src/main/java/br/com/nicomaia/server/commands/handlers/ConnectHandler.java
+++ b/src/main/java/br/com/nicomaia/server/commands/handlers/ConnectHandler.java
@@ -29,7 +29,7 @@ public class ConnectHandler implements CommandHandler {
       try {
         sendResponse(client, new FailureCommandResponse(command));
       } catch (IOException ex) {
-        throw new RuntimeException(ex);
+        logger.log(Level.WARNING, "Failed to send error response", ex);
       }
     }
   }

--- a/src/test/java/br/com/nicomaia/server/commands/ResponseTypeTest.java
+++ b/src/test/java/br/com/nicomaia/server/commands/ResponseTypeTest.java
@@ -29,7 +29,7 @@ class ResponseTypeTest {
 
   @Test
   void shouldThrowForUnknownResponseType() {
-    assertThrows(NoSuchElementException.class, () -> ResponseType.valueOf((byte) 0xFF));
+    assertThrows(IllegalArgumentException.class, () -> ResponseType.valueOf((byte) 0xFF));
   }
 
   @Test


### PR DESCRIPTION
Eliminates all remaining code smells in the codebase.

### Fixes

**1. `ResponseType.valueOf()` — unsafe `.get()`**
- Same fix applied to `AddressType` and `CommandType` in PR #4

**2. `UpdateChecker` — `System.out.println`**
- 8 occurrences replaced with `java.util.logging`
- Update banner preserved with single `logger.info()` call

**3. `ConnectHandler` — `throw new RuntimeException`**
- Replaced with `logger.warning()` — failing to send an error response shouldn't crash the thread

### Result
- ✅ Zero `System.out.println` in codebase
- ✅ Zero `throw new RuntimeException` in codebase
- ✅ Zero unsafe `.get()` on Optional in codebase
- ✅ 60 unit tests passing